### PR TITLE
Disable buggy pthread support

### DIFF
--- a/src/DesktopEarlab/Makefile
+++ b/src/DesktopEarlab/Makefile
@@ -18,7 +18,7 @@ INCLUDE  = ../SupportClasses
 LIBDIR   = ../../lib
 LIBRARY	 = libearlab.a
 CPP      = g++
-CPPFLAGS = -g -I. -I$(INCLUDE) -Dstricmp=strcasecmp -DNOTWINDOWS -DUSE_PTHREADS -fPIC -O3
+CPPFLAGS = -g -I. -I$(INCLUDE) -Dstricmp=strcasecmp -DNOTWINDOWS -fPIC -O3
 # CPPFLAGS = -g -I. -I$(INCLUDE) -Dstricmp=strcasecmp -DNOTWINDOWS -fPIC -O0
 
 all:	$(TARGET) Makefile

--- a/src/SupportClasses/Makefile
+++ b/src/SupportClasses/Makefile
@@ -9,7 +9,7 @@ DEPENDS:=$(patsubst %.cpp,%.d,$(SOURCES))
 include $(DEPENDS)
 
 CPP      = g++
-CPPFLAGS = -I. -Dstricmp=strcasecmp -DNOTWINDOWS -DUSE_PTHREADS -fPIC -g -O3
+CPPFLAGS = -I. -Dstricmp=strcasecmp -DNOTWINDOWS -fPIC -g -O3
 
 all:	$(DEPENDS) $(TARGET) Makefile
 


### PR DESCRIPTION
Earlab on Linux randomly drops a large number of spikes when operating in a multi-threaded manner. This patch disables pthread support on Linux until the bug is fixed.